### PR TITLE
Renamed agents to chaos delegates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ChaosCTL
-The CLC command-line tool, chaosctl, allows you to manage CLC's agent plane. You can use chaosctl to create agents, project, and manage multiple CLC accounts. 
+The CLC command-line tool, chaosctl, allows you to manage CLC's chaos delegate plane. You can use chaosctl to create chaos delegates, project, and manage multiple CLC accounts. 
 
 ## Usage
 * For more information including a complete list of chaosctl operations, see the chaosctl reference documentation. 
@@ -10,7 +10,7 @@ The CLC command-line tool, chaosctl, allows you to manage CLC's agent plane. You
 
 The chaosctl CLI requires the following things:
 
-- kubeconfig - chaosctl needs the kubeconfig of the k8s cluster where we need to connect CLC agents. The CLI currently uses the default path of kubeconfig i.e. `~/.kube/config`.
+- kubeconfig - chaosctl needs the kubeconfig of the k8s cluster where we need to connect CLC chaos delegates. The CLI currently uses the default path of kubeconfig i.e. `~/.kube/config`.
 - kubectl- chaosctl is using kubectl under the hood to apply the manifest. To install kubectl, follow:  [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
 

--- a/Usage.md
+++ b/Usage.md
@@ -7,7 +7,7 @@
 chaosctl [command] [TYPE] [flags]
 ```
 * Command: refers to what you do want to perform (create, get and config)
-* Type: refers to the feature type you are performing a command against (agent, project etc.)
+* Type: refers to the feature type you are performing a command against (chaos delegate, project etc.)
 * Flags: It takes some additional information for resource operations. For example, `--installation-mode` allows you to specify an installation mode.
 
 chaosctl is using the `.chaosconfig` config file to manage multiple accounts
@@ -15,39 +15,39 @@ chaosctl is using the `.chaosconfig` config file to manage multiple accounts
 2. Otherwise, the ${HOME}/.chaosconfig file is used, and no merging takes place.
 
 chaosctl supports both interactive and non-interactive(flag based) modes.
-> Only `chaosctl create agent`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then chaosctl takes input in an interactive mode.
+> Only `chaosctl connect chaos-delegate`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then chaosctl takes input in an interactive mode.
 
 ### Installation modes
-chaosctl can install an agent in two different modes.
-* cluster mode: With this mode, the agent can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=cluster`
+chaosctl can install an chaos delegate in two different modes.
+* cluster mode: With this mode, the chaos delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=cluster`
 
-* namespace mode: With this mode, the agent can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=namespace`
+* namespace mode: With this mode, the chaos delegate can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=namespace`
 
-Note: With namespace mode, the user needs to create the namespace to install the agent as a prerequisite.
+Note: With namespace mode, the user needs to create the namespace to install the chaos delegate as a prerequisite.
 
-### Minimal steps to create an agent
+### Minimal steps to connect an chaos delegate
 
 * To setup an account with chaosctl
 ```shell
 chaosctl config set-account --endpoint="" --access_id="" --access_key=""
 ```
 
-* To create an agent without a project
->Note: If the user doesn't have any project, it will create a random project and add the agent in that random project.
+* To connect an chaos delegate without a project
+>Note: If the user doesn't have any project, it will create a random project and add the chaos delegate in that random project.
 ```shell
-chaosctl create agent --agent-name="" --non-interactive
+chaosctl connect chaos-delegate --chaos-delegate-name="" --non-interactive
 ```
 
 ### Or,
 
-* To create an agent with an existing project
+* To connect an chaos delegate with an existing project
 > Note: To get `project-id`. Apply `chaosctl get projects`
 
 ```shell
-chaosctl create agent --agent-name="" --project-id="" --non-interactive
+chaosctl connect chaos-delegate --chaos-delegate-name="" --project-id="" --non-interactive
 ```
 
-### Flags for `create agent` command
+### Flags for `connect chaos-delegate` command
 <table>
 <tr>
     <th>Flag</th>
@@ -55,28 +55,28 @@ chaosctl create agent --agent-name="" --project-id="" --non-interactive
     <th>Type</th>
     <th>Description</th>
     <tr>
-        <td>--agent-description</td>
+        <td>--chaos-delegate-description</td>
         <td></td>
         <td>String</td>
-        <td>Set the agent description (default "---")</td>
+        <td>Set the chaos delegate description (default "---")</td>
     </tr>
     <tr>
-        <td>--agent-name</td>
+        <td>--chaos-delegate-name</td>
         <td></td>
         <td>String</td>
-        <td>Set the cluster-type to external for external agents | Supported=external/internal (default "external")</td>
+        <td>Set the cluster-type to external for external chaos delegates | Supported=external/internal (default "external")</td>
     </tr>
     <tr>
         <td>--cluster-type</td>
         <td></td>
         <td>String</td>
-        <td>Set the cluster-type to external for external agents | Supported=external/internal (default "external")</td>
+        <td>Set the cluster-type to external for external chaos delegates | Supported=external/internal (default "external")</td>
     </tr>
     <tr>
         <td>--installation-mode</td>
         <td></td>
         <td>String</td>
-        <td>Set the installation mode for the kind of agent | Supported=cluster/namespace (default "cluster")</td>
+        <td>Set the installation mode for the kind of chaos delegate | Supported=cluster/namespace (default "cluster")</td>
     </tr>
     <tr>
         <td>--kubeconfig</td>
@@ -88,13 +88,13 @@ chaosctl create agent --agent-name="" --project-id="" --non-interactive
         <td>--namespace</td>
         <td></td>
         <td>String</td>
-        <td>Set the namespace for the agent installation (default "litmus")</td>
+        <td>Set the namespace for the chaos delegate installation (default "litmus")</td>
     </tr>
     <tr>
         <td>--node-selector</td>
         <td></td>
         <td>String</td>
-        <td>Set the node-selector for agent components | Format: key1=value1,key2=value2)
+        <td>Set the node-selector for chaos delegate components | Format: key1=value1,key2=value2)
     </tr>
     <tr>
         <td>--non-interactive</td>
@@ -124,7 +124,7 @@ chaosctl create agent --agent-name="" --project-id="" --non-interactive
         <td>--service-account</td>
         <td></td>
         <td>String</td>
-        <td>Set the service account to be used by the agent (default "litmus")</td>
+        <td>Set the service account to be used by the chaos delegate (default "litmus")</td>
     </tr>
     <tr>
         <td>--config</td>
@@ -197,17 +197,17 @@ PROJECT ID                                PROJECT NAME       CREATEDAT
 ```
 
 
-* To get an overview of the agents available within a project, issue the following command.
+* To get an overview of the chaos delegates available within a project, issue the following command.
 ```shell
-chaosctl get agents --project-id=""
+chaosctl get chaos-delegates --project-id=""
 ```
 
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS 
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE 
-13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
+CHAOS DELEGATE ID                                CHAOS DELEGATE NAME          STATUS 
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   chaos-delegate-1            ACTIVE 
+13dsf3d1-5324-54af-4g23-5331g5v2364f   chaos-delegate-2            INACTIVE
 ```
 
 

--- a/Usage.md
+++ b/Usage.md
@@ -18,21 +18,21 @@ chaosctl supports both interactive and non-interactive(flag based) modes.
 > Only `chaosctl connect chaos-delegate`  command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then chaosctl takes input in an interactive mode.
 
 ### Installation modes
-chaosctl can install an chaos delegate in two different modes.
+chaosctl can install a chaos delegate in two different modes.
 * cluster mode: With this mode, the chaos delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=cluster`
 
 * namespace mode: With this mode, the chaos delegate can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode. It can be enabled by passing a flag `--installation-mode=namespace`
 
 Note: With namespace mode, the user needs to create the namespace to install the chaos delegate as a prerequisite.
 
-### Minimal steps to connect an chaos delegate
+### Minimal steps to connect a chaos delegate
 
 * To setup an account with chaosctl
 ```shell
 chaosctl config set-account --endpoint="" --access_id="" --access_key=""
 ```
 
-* To connect an chaos delegate without a project
+* To connect a chaos delegate without a project
 >Note: If the user doesn't have any project, it will create a random project and add the chaos delegate in that random project.
 ```shell
 chaosctl connect chaos-delegate --chaos-delegate-name="" --non-interactive
@@ -40,7 +40,7 @@ chaosctl connect chaos-delegate --chaos-delegate-name="" --non-interactive
 
 ### Or,
 
-* To connect an chaos delegate with an existing project
+* To connect a chaos delegate with an existing project
 > Note: To get `project-id`. Apply `chaosctl get projects`
 
 ```shell

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -21,7 +21,7 @@ chaosctl supports both interactive and non-interactive(flag based) modes.
 
 > Only `chaosctl connect chaos-delegate` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then chaosctl takes input in an interactive mode.
 
-### Steps to create an chaos delegate
+### Steps to connect a chaos delegate
 
 - To setup an account with chaosctl
 
@@ -40,8 +40,8 @@ Next, you need to enter CLC/CLE details to login into your account. Fields to be
 
 ```
 ? What's the product name?:
-  ▸ ChaosNative Cloud
-    ChaosNative Enterprise
+  ▸ Harness Chaos Engineering Cloud
+    Harness Chaos Engineering Enterprise
 
 What's the AccessID?: Raj60163RjxQE
 What's the AccessKey?: ***************
@@ -49,7 +49,7 @@ What's the AccessKey?: ***************
 account.accessID/admin configured
 ```
 
-- To connect an chaos delegate in a cluster mode
+- To connect a chaos delegate in a cluster mode
 
 ```shell
 chaosctl connect chaos-delegate
@@ -64,7 +64,7 @@ There will be a list of existing projects displayed on the terminal. Select the 
 
 Next, select the installation mode based on your requirement by entering the sequence number indicated against it.
 
-It can install an chaos delegate in two different modes.
+It can install a chaos delegate in two different modes.
 
 - cluster mode: With this mode, the chaos delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode.
 
@@ -119,7 +119,7 @@ Fields to be filled in <br />
 
 ```
 Enter the details of the chaos delegate
-✔ What's the chaos delegate Name?: new-chaos-delegate
+✔ What's the chaos delegate name?: new-chaos-delegate
 
 ✔ Add your chaos delegate description: This is a new chaos-delegate
 
@@ -224,8 +224,8 @@ CURRENT  ENDPOINT                         ACCESSID  EXPIRESIN
 chaosctl config use-account
 
 ? What's the product name?:
-  ▸ ChaosNative Cloud
-    ChaosNative Enterprise
+  ▸ Harness Chaos Engineering Cloud
+    Harness Chaos Engineering Enterprise
 
 What's the AccessID?: Raj60163RjxQE
 ```

--- a/Usage_interactive.md
+++ b/Usage_interactive.md
@@ -9,7 +9,7 @@ chaosctl [command] [TYPE] [flags]
 ```
 
 - Command: refers to what you do want to perform (create, get and config)
-- Type: refers to the feature type you are performing a command against (agent, project etc.)
+- Type: refers to the feature type you are performing a command against (chaos delegate, project etc.)
 - Flags: It takes some additional information for resource operations. For example, `--installation-mode` allows you to specify an installation mode.
 
 chaosctl is using the `.chaosconfig` config file to manage multiple accounts
@@ -19,9 +19,9 @@ chaosctl is using the `.chaosconfig` config file to manage multiple accounts
 
 chaosctl supports both interactive and non-interactive(flag based) modes.
 
-> Only `chaosctl create agent` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then chaosctl takes input in an interactive mode.
+> Only `chaosctl connect chaos-delegate` command needs --non-interactive flag, other commands don't need this flag to be in non-interactive mode. If mandatory flags aren't passed, then chaosctl takes input in an interactive mode.
 
-### Steps to create an agent
+### Steps to create an chaos delegate
 
 - To setup an account with chaosctl
 
@@ -49,10 +49,10 @@ What's the AccessKey?: ***************
 account.accessID/admin configured
 ```
 
-- To create an agent in a cluster mode
+- To connect an chaos delegate in a cluster mode
 
 ```shell
-chaosctl create agent
+chaosctl connect chaos-delegate
 ```
 
 There will be a list of existing projects displayed on the terminal. Select the desired project by entering the sequence number indicated against it.
@@ -64,13 +64,13 @@ There will be a list of existing projects displayed on the terminal. Select the 
 
 Next, select the installation mode based on your requirement by entering the sequence number indicated against it.
 
-It can install an agent in two different modes.
+It can install an chaos delegate in two different modes.
 
-- cluster mode: With this mode, the agent can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode.
+- cluster mode: With this mode, the chaos delegate can run the chaos in any namespace. It installs appropriate cluster roles and cluster role bindings to achieve this mode.
 
-- namespace mode: With this mode, the agent can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode.
+- namespace mode: With this mode, the chaos delegate can run the chaos in its namespace. It installs appropriate roles and role bindings to achieve this mode.
 
-Note: With namespace mode, the user needs to create the namespace to install the agent as a prerequisite.
+Note: With namespace mode, the user needs to create the namespace to install the chaos delegate as a prerequisite.
 
 ```
 ? What's the installation mode?:
@@ -80,11 +80,11 @@ Note: With namespace mode, the user needs to create the namespace to install the
 🏃 Running prerequisites check....
 🔑 clusterrole ✅
 🔑 clusterrolebinding ✅
-🌟 Sufficient permissions. Installing the Agent...
+🌟 Sufficient permissions. Installing the chaos delegate...
 
 ```
 
-Next, enter the details of the new agent.
+Next, enter the details of the new chaos delegate.
 
 Fields to be filled in <br />
 
@@ -92,20 +92,20 @@ Fields to be filled in <br />
     <th>Field</th>
     <th>Description</th>
     <tr>
-        <td>Agent Name:</td>
-        <td>Enter a name of the agent which needs to be unique across the project</td>
+        <td>Chaos Delegate Name:</td>
+        <td>Enter a name of the chaos delegate which needs to be unique across the project</td>
     </tr>
     <tr>
-        <td>Agent Description:</td>
-        <td>Fill in details about the agent</td>
+        <td>Chaos Delegate Description:</td>
+        <td>Fill in details about the chaos delegate</td>
     </tr>
     <tr>
         <td>Node Selector:</td>
-        <td>To deploy the agent on a particular node based on the node selector labels</td>
+        <td>To deploy the chaos delegate on a particular node based on the node selector labels</td>
     </tr>
     <tr>
         <td>Platform Name:</td>
-        <td>Enter the platform name on which this agent is hosted. For example, AWS, GCP, Rancher etc.</td>
+        <td>Enter the platform name on which this chaos delegate is hosted. For example, AWS, GCP, Rancher etc.</td>
     </tr>
     <tr>
         <td>Enter the namespace:</td>
@@ -118,16 +118,16 @@ Fields to be filled in <br />
 </table>
 
 ```
-Enter the details of the agent
-✔ What's the Agent Name?: new-agent
+Enter the details of the chaos delegate
+✔ What's the chaos delegate Name?: new-chaos-delegate
 
-✔ Add your agent description: new-agent█
+✔ Add your chaos delegate description: This is a new chaos-delegate
 
-? Do you want NodeSelectors added to the agent deployments?:
+? Do you want NodeSelectors added to the chaos delegate deployments?:
     Yes
   ▸ No
 
-? Do you want Tolerations added in the agent deployments??:
+? Do you want Tolerations added in the chaos delegate deployments??:
     Yes
   ▸ No
 
@@ -144,14 +144,14 @@ Enter the details of the agent
 ```
 
 Once, all these steps are implemented you will be able to see a summary of all the entered fields.
-After verification of these details, you can proceed with the connection of the agent by entering Y. The process of connection might take up to a few seconds.
+After verification of these details, you can proceed with the connection of the chaos delegate by entering Y. The process of connection might take up to a few seconds.
 
 ```
 Enter service account [Default: litmus]:
 
 📌 Summary
-Agent Name: New-Agent
-Agent Description: This is a new agent
+Chaos Delegate Name: new-chaos-delegate
+Chaos Delegate Description: This is a new chaos-delegate
 Platform Name: Others
 Namespace:  litmus
 Service Account:  litmus (new)
@@ -161,20 +161,20 @@ Installation Mode: cluster
   ▸ Yes
     No
 
-👍 Continuing agent connection!!
+👍 Continuing chaos delegate connection!!
 Applying YAML:
 https://preview.litmuschaos.io/api/file/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiMDUyZmFlN2UtZGM0MS00YmU4LWJiYTgtMmM4ZTYyNDFkN2I0In0.i31QQDG92X5nD6P_-7TfeAAarZqLvUTFfnAghJYXPiM.yaml
 
-💡 Connecting agent to Chaos Center.
-🏃 Agents are running!!
+💡 Connecting chaos delegate to Chaos Center.
+🏃 Chaos Delegates are running!!
 
-🚀 Agent Connection Successful!! 🎉
-👉 Litmus agents can be accessed here: https://cloud.chaosnative.com/agents
+🚀 Chaos Delegate Connection Successful!! 🎉
+👉 Litmus chaos delegates can be accessed here: https://cloud.chaosnative.com/delegates
 ```
 
-#### Verify the new Agent Connection\*\*
+#### Verify the new Chaos Delegate Connection\*\*
 
-To verify, if the connection process was successful you can view the list of connected agents from the Targets section on your ChaosCenter and ensure that the connected agent is in Active State.
+To verify, if the connection process was successful you can view the list of connected chaos delegates from the Targets section on your ChaosCenter and ensure that the connected chaos delegate is in Active State.
 
 ---
 
@@ -252,10 +252,10 @@ PROJECT ID                                PROJECT NAME       CREATEDAT
 7a4a259a-1ae5-4204-ae83-89a8838eaec3      DevOps Project     2021-07-21 14:39:14 +0530 IST
 ```
 
-- To get an overview of the agents available within a project, issue the following command.
+- To get an overview of the chaos delegates available within a project, issue the following command.
 
 ```shell
-chaosctl get agents
+chaosctl get chaos-delegates
 
 Enter the Project ID: 50addd40-8767-448c-a91a-5071543a2d8e
 ```
@@ -263,9 +263,9 @@ Enter the Project ID: 50addd40-8767-448c-a91a-5071543a2d8e
 **Output:**
 
 ```
-AGENTID                                AGENTNAME          STATUS
-55ecc7f2-2754-43aa-8e12-6903e4c6183a   agent-1            ACTIVE
-13dsf3d1-5324-54af-4g23-5331g5v2364f   agent-2            INACTIVE
+CHAOS DELEGATE ID                                CHAOS DELEGATE NAME          STATUS
+55ecc7f2-2754-43aa-8e12-6903e4c6183a   chaos-delagate-1            ACTIVE
+13dsf3d1-5324-54af-4g23-5331g5v2364f   chaos-delegate-2            INACTIVE
 ```
 
 For more information related to flags, Use `chaosctl --help`.

--- a/pkg/agent/ops.go
+++ b/pkg/agent/ops.go
@@ -17,13 +17,14 @@ package agent
 
 import (
 	"errors"
+	"os"
+	"strconv"
+
 	"github.com/chaosnative/chaosctl/pkg/apis"
 	"github.com/chaosnative/chaosctl/pkg/k8s"
 	"github.com/chaosnative/chaosctl/pkg/types"
 	"github.com/chaosnative/chaosctl/pkg/utils"
 	"github.com/manifoldco/promptui"
-	"os"
-	"strconv"
 )
 
 // GetProject display list of projects and returns the project id based on input
@@ -48,7 +49,7 @@ func GetProjectID(u apis.ProjectDetails) string {
 	return u.Data.Projects[counter].ID
 }
 
-// GetMode gets mode of agent installation as input
+// GetMode gets mode of chaos delegate installation as input
 func GetModeType() string {
 	prompt := promptui.Select{
 		Label: "What's the installation mode?",
@@ -71,19 +72,19 @@ func GetModeType() string {
 	return utils.DefaultMode
 }
 
-// GetAgentDetails take details of agent as input
+// GetAgentDetails take details of chaos delegate as input
 func GetAgentDetails(mode string, pid string, c types.Credentials, kubeconfig *string) (types.Agent, error) {
 	var (
 		newAgent types.Agent
 		err      error
 	)
-	// Get agent name as input
-	utils.White_B.Println("\nEnter the details of the agent")
-	// Label for goto statement in case of invalid agent name
+	// Get chaos delegate name as input
+	utils.White_B.Println("\nEnter the details of the chaos delegate")
+	// Label for goto statement in case of invalid chaos delegate name
 
 AGENT_NAME:
 	prompt := promptui.Prompt{
-		Label: "What's the Agent Name?",
+		Label: "What's the chaos delegate Name?",
 	}
 
 	newAgent.AgentName, err = prompt.Run()
@@ -93,7 +94,7 @@ AGENT_NAME:
 	}
 
 	if newAgent.AgentName == "" {
-		utils.Red.Println("⛔ Agent name cannot be empty. Please enter a valid name.")
+		utils.Red.Println("⛔ Chaos Delegate name cannot be empty. Please enter a valid name.")
 		goto AGENT_NAME
 	}
 
@@ -117,7 +118,7 @@ AGENT_NAME:
 
 	// Get agent description as input
 	prompt = promptui.Prompt{
-		Label: "Add your agent description",
+		Label: "Add your chaos delegate description",
 	}
 
 	newAgent.Description, err = prompt.Run()
@@ -127,7 +128,7 @@ AGENT_NAME:
 	}
 
 	nodeSelector := promptui.Select{
-		Label: "Do you want NodeSelectors added to the agent deployments?",
+		Label: "Do you want NodeSelectors added to the chaos delegate deployments?",
 		Items: []string{"Yes", "No"},
 	}
 
@@ -153,7 +154,7 @@ AGENT_NAME:
 	}
 
 	toleration := promptui.Select{
-		Label: "Do you want Tolerations added in the agent deployments??",
+		Label: "Do you want Tolerations added in the chaos delegate deployments??",
 		Items: []string{"Yes", "No"},
 	}
 
@@ -285,12 +286,12 @@ func ValidateSAPermissions(mode string, kubeconfig *string) {
 		}
 	}
 
-	utils.White_B.Println("\n🌟 Sufficient permissions. Installing the Agent...")
+	utils.White_B.Println("\n🌟 Sufficient permissions. Installing the chaos delegate...")
 }
 
 // Summary display the agent details based on input
 func Summary(agent types.Agent, kubeconfig *string) {
-	utils.White_B.Printf("\n📌 Summary \nAgent Name: %s\nAgent Description: %s\nPlatform Name: %s\n", agent.AgentName, agent.Description, agent.PlatformName)
+	utils.White_B.Printf("\n📌 Summary \nChaos Delegate Name: %s\nChaos Delegate Description: %s\nPlatform Name: %s\n", agent.AgentName, agent.Description, agent.PlatformName)
 	if ok, _ := k8s.NsExists(agent.Namespace, kubeconfig); ok {
 		utils.White_B.Println("Namespace: ", agent.Namespace)
 	} else {
@@ -320,9 +321,9 @@ func ConfirmInstallation() {
 	}
 
 	if decision == 0 {
-		utils.White_B.Println("👍 Continuing agent connection!!")
+		utils.White_B.Println("👍 Continuing chaos delegate connection!!")
 	} else {
-		utils.Red.Println("✋ Exiting agent connection!!")
+		utils.Red.Println("✋ Exiting chaos delegate connection!!")
 		os.Exit(1)
 	}
 }

--- a/pkg/agent/ops.go
+++ b/pkg/agent/ops.go
@@ -84,7 +84,7 @@ func GetAgentDetails(mode string, pid string, c types.Credentials, kubeconfig *s
 
 AGENT_NAME:
 	prompt := promptui.Prompt{
-		Label: "What's the chaos delegate Name?",
+		Label: "What's the chaos delegate name?",
 	}
 
 	newAgent.AgentName, err = prompt.Run()

--- a/pkg/apis/agent.go
+++ b/pkg/apis/agent.go
@@ -47,19 +47,19 @@ type AgentList struct {
 	GetAgent []AgentDetails `json:"getCluster"`
 }
 
-// GetAgentList lists the agent connected to the specified project
+// GetAgentList lists the chaos delegate connected to the specified project
 func GetAgentList(c types.Credentials, pid string) (AgentData, error) {
 	query := `{"query":"query{\n  getCluster(project_id: \"` + pid + `\"){\n  cluster_id cluster_name is_active \n  }\n}"}`
 	resp, err := SendRequest(SendRequestParams{Endpoint: c.Endpoint + utils.GQLAPIPath, Token: c.Token}, []byte(query), string(types.Post))
 	if err != nil {
-		utils.Red.Println("Error in getting agent list: ", err)
+		utils.Red.Println("Error in getting chaos delegate list: ", err)
 		os.Exit(1)
 	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		utils.Red.Println("Error in getting agent list: ", err)
+		utils.Red.Println("Error in getting chaos delegate list: ", err)
 		os.Exit(1)
 	}
 
@@ -67,7 +67,7 @@ func GetAgentList(c types.Credentials, pid string) (AgentData, error) {
 		var agent AgentData
 		err = json.Unmarshal(bodyBytes, &agent)
 		if err != nil {
-			utils.Red.Println("Error in getting agent list: ", err)
+			utils.Red.Println("Error in getting chaos delegate list: ", err)
 			os.Exit(1)
 		}
 		return agent, nil
@@ -99,7 +99,7 @@ type UserAgentReg struct {
 	Token       string `json:"token"`
 }
 
-// ConnectAgent connects the agent with the given details
+// ConnectAgent connects the chaos delegate with the given details
 func ConnectAgent(agent types.Agent, cred types.Credentials) (AgentConnectionData, error) {
 	query := `{"query":"mutation {\n  userClusterReg(clusterInput: \n    { \n    cluster_name: \"` + agent.AgentName + `\", \n    description: \"` + agent.Description + `\",\n  \tplatform_name: \"` + agent.PlatformName + `\",\n    project_id: \"` + agent.ProjectId + `\",\n    cluster_type: \"` + agent.ClusterType + `\",\n  agent_scope: \"` + agent.Mode + `\",\n    agent_namespace: \"` + agent.Namespace + `\",\n    serviceaccount: \"` + agent.ServiceAccount + `\",\n    agent_ns_exists: ` + fmt.Sprintf("%t", agent.NsExists) + `,\n    agent_sa_exists: ` + fmt.Sprintf("%t", agent.SAExists) + `,\n  }){\n    cluster_id\n    cluster_name\n    token\n  }\n}"}`
 
@@ -117,19 +117,19 @@ func ConnectAgent(agent types.Agent, cred types.Credentials) (AgentConnectionDat
 
 	resp, err := SendRequest(SendRequestParams{Endpoint: cred.Endpoint + utils.GQLAPIPath, Token: cred.Token}, []byte(query), string(types.Post))
 	if err != nil {
-		return AgentConnectionData{}, errors.New("Error in registering agent: " + err.Error())
+		return AgentConnectionData{}, errors.New("Error in registering chaos delegate: " + err.Error())
 	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return AgentConnectionData{}, errors.New("Error in registering agent: " + err.Error())
+		return AgentConnectionData{}, errors.New("Error in registering chaos delegate: " + err.Error())
 	}
 
 	if resp.StatusCode == http.StatusOK {
 		var connectAgent AgentConnectionData
 		err = json.Unmarshal(bodyBytes, &connectAgent)
 		if err != nil {
-			return AgentConnectionData{}, errors.New("Error in registering agent: " + err.Error())
+			return AgentConnectionData{}, errors.New("Error in registering chaos delegate: " + err.Error())
 		}
 		return connectAgent, nil
 	} else {

--- a/pkg/apis/upgrade.go
+++ b/pkg/apis/upgrade.go
@@ -86,7 +86,7 @@ func UpgradeAgent(c context.Context, cred types.Credentials, projectID string, c
 		}
 
 		// To write the manifest data into a temporary file
-		err = ioutil.WriteFile("agent-manifest.yaml", []byte(manifest.Data.GetManifest), 0644)
+		err = ioutil.WriteFile("chaos-delegate-manifest.yaml", []byte(manifest.Data.GetManifest), 0644)
 		if err != nil {
 			return "", err
 		}
@@ -118,7 +118,7 @@ func UpgradeAgent(c context.Context, cred types.Credentials, projectID string, c
 		yamlOutput, err := k8s.ApplyYaml(k8s.ApplyYamlPrams{
 			Token:    cred.Token,
 			Endpoint: cred.Endpoint,
-			YamlPath: "agent-manifest.yaml",
+			YamlPath: "chaos-delegate-manifest.yaml",
 		}, "", true)
 
 		if err != nil {
@@ -126,7 +126,7 @@ func UpgradeAgent(c context.Context, cred types.Credentials, projectID string, c
 		}
 		utils.White.Print("\n", yamlOutput)
 
-		err = os.Remove("agent-manifest.yaml")
+		err = os.Remove("chaos-delegate-manifest.yaml")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cmd/config/useAccount.go
+++ b/pkg/cmd/config/useAccount.go
@@ -40,7 +40,7 @@ var useAccountCmd = &cobra.Command{
 		if endpoint == "" {
 			prompt := promptui.Select{
 				Label: "What's the product name?",
-				Items: []string{"ChaosNative Cloud", "ChaosNative Enterprise"},
+				Items: []string{"Harness Chaos Engineering Cloud", "Harness Chaos Engineering Enterprise"},
 			}
 
 			_, result, err := prompt.Run()
@@ -50,9 +50,9 @@ var useAccountCmd = &cobra.Command{
 				return
 			}
 
-			if result == "ChaosNative Cloud" {
+			if result == "Harness Chaos Engineering Cloud" {
 				endpoint = utils.HarnessChaosEngineeringCloudEndpoint
-			} else if result == "ChaosNative Enterprise" {
+			} else if result == "Harness Chaos Engineering Enterprise" {
 				validate := func(input string) error {
 					if utils.IsValidUrl(input) {
 						return nil
@@ -69,7 +69,7 @@ var useAccountCmd = &cobra.Command{
 				}
 
 				prompt := promptui.Prompt{
-					Label:     "ChaosNative Enterprise Endpoint",
+					Label:     "Harness Chaos Engineering Enterprise Endpoint",
 					Templates: templates,
 					Validate:  validate,
 				}

--- a/pkg/cmd/connect/agent.go
+++ b/pkg/cmd/connect/agent.go
@@ -34,10 +34,10 @@ var agentCmd = &cobra.Command{
 	Use: "chaos-delegate",
 	Short: `connect an external chaos delegate.
 	Example(s):
-	#connect an chaos delegate
+	#connect a chaos delegate
 	chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --non-interactive
 
-	#connect an chaos delegate within a project
+	#connect a chaos delegate within a project
 	chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 	
 	Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag
@@ -233,7 +233,7 @@ var agentCmd = &cobra.Command{
 			path := fmt.Sprintf("%s/%s/%s.yaml", credentials.Endpoint, utils.ChaosYamlPath, agent.Data.UserAgentReg.Token)
 			utils.White_B.Print("Applying YAML:\n", path)
 		} else {
-			utils.Red.Print("\n🚫 Token Generation failed, Chaos Delegate installation failed\n")
+			utils.Red.Print("\n🚫 Token Generation failed, chaos delegate installation failed\n")
 			os.Exit(1)
 		}
 

--- a/pkg/cmd/connect/agent.go
+++ b/pkg/cmd/connect/agent.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package create
+package connect
 
 import (
 	"encoding/json"
@@ -29,16 +29,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// agentCmd represents the agent command
+// agentCmd represents the chaos delegate command
 var agentCmd = &cobra.Command{
-	Use: "agent",
-	Short: `Create an external agent.
+	Use: "chaos-delegate",
+	Short: `connect an external chaos delegate.
 	Example(s):
-	#create an agent
-	chaosctl create agent --agent-name="new-agent" --non-interactive
+	#connect an chaos delegate
+	chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --non-interactive
 
-	#create an agent within a project
-	chaosctl create agent --agent-name="new-agent" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+	#connect an chaos delegate within a project
+	chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 	
 	Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag
 `,
@@ -89,15 +89,15 @@ var agentCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			newAgent.AgentName, err = cmd.Flags().GetString("agent-name")
+			newAgent.AgentName, err = cmd.Flags().GetString("chaos-delegate-name")
 			utils.PrintError(err)
 
 			if newAgent.AgentName == "" {
-				utils.Red.Print("Error: --agent-name flag is empty")
+				utils.Red.Print("Error: --chaos-delegate-name flag is empty")
 				os.Exit(1)
 			}
 
-			newAgent.Description, err = cmd.Flags().GetString("agent-description")
+			newAgent.Description, err = cmd.Flags().GetString("chaos-delegate-description")
 			utils.PrintError(err)
 
 			newAgent.PlatformName, err = cmd.Flags().GetString("platform-name")
@@ -226,14 +226,14 @@ var agentCmd = &cobra.Command{
 		}
 		agent, err := apis.ConnectAgent(newAgent, credentials)
 		if err != nil {
-			utils.Red.Println("\n❌ Agent connection failed: " + err.Error() + "\n")
+			utils.Red.Println("\n❌ Chaos Delegate connection failed: " + err.Error() + "\n")
 			os.Exit(1)
 		}
 		if agent.Data.UserAgentReg.Token != "" {
 			path := fmt.Sprintf("%s/%s/%s.yaml", credentials.Endpoint, utils.ChaosYamlPath, agent.Data.UserAgentReg.Token)
 			utils.White_B.Print("Applying YAML:\n", path)
 		} else {
-			utils.Red.Print("\n🚫 Token Generation failed, Agent installation failed\n")
+			utils.Red.Print("\n🚫 Token Generation failed, Chaos Delegate installation failed\n")
 			os.Exit(1)
 		}
 
@@ -253,27 +253,27 @@ var agentCmd = &cobra.Command{
 		// Watch subscriber pod status
 		k8s.WatchPod(k8s.WatchPodParams{Namespace: newAgent.Namespace, Label: utils.ChaosAgentLabel}, &kubeconfig)
 
-		utils.White_B.Println("\n🚀 Agent Connection Successful!! 🎉")
-		utils.White_B.Println("👉 Agents can be accessed here: " + fmt.Sprintf("%s/%s", credentials.Endpoint, utils.ChaosAgentPath))
+		utils.White_B.Println("\n🚀 Chaos Delegate Connection Successful!! 🎉")
+		utils.White_B.Println("👉 Chaos Delegates can be accessed here: " + fmt.Sprintf("%s/%s", credentials.Endpoint, utils.ChaosAgentPath))
 	},
 }
 
 func init() {
-	CreateCmd.AddCommand(agentCmd)
+	ConnectCmd.AddCommand(agentCmd)
 
 	agentCmd.Flags().BoolP("non-interactive", "n", false, "Set it to true for non interactive mode | Note: Always set the boolean flag as --non-interactive=Boolean")
 	agentCmd.Flags().StringP("kubeconfig", "k", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")
 	agentCmd.Flags().String("tolerations", "", "Set to pass kubeconfig file if it is not in the default location ($HOME/.kube/config)")
 
-	agentCmd.Flags().String("project-id", "", "Set the project-id to install agent for the particular project. To see the projects, apply chaosctl get projects")
-	agentCmd.Flags().String("installation-mode", "cluster", "Set the installation mode for the kind of agent | Supported=cluster/namespace")
-	agentCmd.Flags().String("agent-name", "", "Set the agent name")
-	agentCmd.Flags().String("agent-description", "---", "Set the agent description")
+	agentCmd.Flags().String("project-id", "", "Set the project-id to install chaos-delegate for the particular project. To see the projects, apply chaosctl get projects")
+	agentCmd.Flags().String("installation-mode", "cluster", "Set the installation mode for the kind of chaos-delegate | Supported=cluster/namespace")
+	agentCmd.Flags().String("chaos-delegate-name", "", "Set the chaos-delegate name")
+	agentCmd.Flags().String("chaos-delegate-description", "---", "Set the chaos-delegate description")
 	agentCmd.Flags().String("platform-name", "Others", "Set the platform name. Supported- AWS/GKE/Openshift/Rancher/Others")
-	agentCmd.Flags().String("cluster-type", "external", "Set the cluster-type to external for external agents | Supported=external/internal")
-	agentCmd.Flags().String("node-selector", "", "Set the node-selector for agent components | Format: \"key1=value1,key2=value2\")")
-	agentCmd.Flags().String("namespace", "litmus", "Set the namespace for the agent installation")
-	agentCmd.Flags().String("service-account", "litmus", "Set the service account to be used by the agent")
+	agentCmd.Flags().String("cluster-type", "external", "Set the cluster-type to external for external chaos-delegates | Supported=external/internal")
+	agentCmd.Flags().String("node-selector", "", "Set the node-selector for chaos-delegate components | Format: \"key1=value1,key2=value2\")")
+	agentCmd.Flags().String("namespace", "litmus", "Set the namespace for the chaos-delegate installation")
+	agentCmd.Flags().String("service-account", "litmus", "Set the service account to be used by the chaos-delegate")
 	agentCmd.Flags().Bool("ns-exists", false, "Set the --ns-exists=false if the namespace mentioned in the --namespace flag is not existed else set it to --ns-exists=true | Note: Always set the boolean flag as --ns-exists=Boolean")
 	agentCmd.Flags().Bool("sa-exists", false, "Set the --sa-exists=false if the service-account mentioned in the --service-account flag is not existed else set it to --sa-exists=true | Note: Always set the boolean flag as --sa-exists=Boolean\"\n")
 }

--- a/pkg/cmd/connect/connect.go
+++ b/pkg/cmd/connect/connect.go
@@ -13,19 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package create
+package connect
 
 import (
 	"github.com/spf13/cobra"
 )
 
 // createCmd represents the create command
-var CreateCmd = &cobra.Command{
-	Use: "create",
-	Short: `create resources for ChaosCenter chaos delegate plane.
+var ConnectCmd = &cobra.Command{
+	Use: "connect",
+	Short: `connect resources for ChaosCenter chaos delegate plane.
 		Examples:
-		#create a project
-		chaosctl create project --name new-proj
+		#connect an chaos-delegate
+		chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --non-interactive
+
+		#connect an chaos-delegate within a project
+		chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 		
 		Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/connect/connect.go
+++ b/pkg/cmd/connect/connect.go
@@ -24,10 +24,10 @@ var ConnectCmd = &cobra.Command{
 	Use: "connect",
 	Short: `connect resources for ChaosCenter chaos delegate plane.
 		Examples:
-		#connect an chaos-delegate
+		#connect a chaos-delegate
 		chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --non-interactive
 
-		#connect an chaos-delegate within a project
+		#connect a chaos-delegate within a project
 		chaosctl connect chaos-delegate --chaos-delegate-name="new-chaos-delegate" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 		
 		Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag

--- a/pkg/cmd/get/agents.go
+++ b/pkg/cmd/get/agents.go
@@ -16,19 +16,20 @@ limitations under the License.
 package get
 
 import (
+	"os"
+	"text/tabwriter"
+
 	"github.com/chaosnative/chaosctl/pkg/apis"
 	"github.com/chaosnative/chaosctl/pkg/utils"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"os"
-	"text/tabwriter"
 )
 
-// agentsCmd represents the agents command
+// agentsCmd represents the chaos delegates command
 var agentsCmd = &cobra.Command{
-	Use:   "agents",
-	Short: "Display list of agents within the project",
-	Long:  `Display list of agents within the project`,
+	Use:   "chaos-delegates",
+	Short: "Display list of chaos delegates within the project",
+	Long:  `Display list of chaos delegates within the project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -69,7 +70,7 @@ var agentsCmd = &cobra.Command{
 		case "":
 
 			writer := tabwriter.NewWriter(os.Stdout, 4, 8, 1, '\t', 0)
-			utils.White_B.Fprintln(writer, "AGENTID\tAGENTNAME\tSTATUS\t")
+			utils.White_B.Fprintln(writer, "CHAOS DELEGATE\tCHAOS DELEGATE NAME\tSTATUS\t")
 
 			for _, agent := range agents.Data.GetAgent {
 				var status string

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -26,8 +26,8 @@ var GetCmd = &cobra.Command{
 		#get list of projects accessed by the user
 		chaosctl get projects
 
-		#get list of agents within the project
-		chaosctl get agents --project-id=""
+		#get list of chaos delegates within the project
+		chaosctl get chaos-delegates --project-id=""
 
 		Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/chaosnative/chaosctl/pkg/cmd/connect"
 	"github.com/chaosnative/chaosctl/pkg/cmd/hubgen"
 
 	"github.com/chaosnative/chaosctl/pkg/cmd/upgrade"
@@ -39,8 +40,8 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "chaosctl",
-	Short: "ChaosCTL controls the ChaosNative cloud agent plane",
-	Long:  `ChaosCTL controls the ChaosNative cloud agent plane. ` + "\n" + ` Find more information at: https://github.com/chaosnative/chaosctl`,
+	Short: "ChaosCTL controls the ChaosNative cloud chaos delegate plane",
+	Long:  `ChaosCTL controls the ChaosNative cloud chaos delegate plane. ` + "\n" + ` Find more information at: https://github.com/chaosnative/chaosctl`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -54,6 +55,7 @@ func init() {
 
 	rootCmd.AddCommand(config.ConfigCmd)
 	rootCmd.AddCommand(create.CreateCmd)
+	rootCmd.AddCommand(connect.ConnectCmd)
 	rootCmd.AddCommand(get.GetCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(upgrade.UpgradeCmd)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -40,8 +40,8 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "chaosctl",
-	Short: "ChaosCTL controls the ChaosNative cloud chaos delegate plane",
-	Long:  `ChaosCTL controls the ChaosNative cloud chaos delegate plane. ` + "\n" + ` Find more information at: https://github.com/chaosnative/chaosctl`,
+	Short: "ChaosCTL controls the Harness Chaos Engineering Cloud chaos delegate plane",
+	Long:  `ChaosCTL controls the Harness Chaos Engineering Cloud chaos delegate plane. ` + "\n" + ` Find more information at: https://github.com/chaosnative/chaosctl`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/cmd/upgrade/agent.go
+++ b/pkg/cmd/upgrade/agent.go
@@ -30,7 +30,7 @@ import (
 // createCmd represents the create command
 var agentCmd = &cobra.Command{
 	Use:   "chaos-delegate",
-	Short: `Upgrades the ChaosNative Cloud Chaos Delegate plane.`,
+	Short: `Upgrades the Harness Chaos Engineering Cloud Chaos Delegate plane.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)

--- a/pkg/cmd/upgrade/agent.go
+++ b/pkg/cmd/upgrade/agent.go
@@ -18,8 +18,9 @@ package upgrade
 import (
 	"context"
 	"errors"
-	"github.com/manifoldco/promptui"
 	"os"
+
+	"github.com/manifoldco/promptui"
 
 	"github.com/chaosnative/chaosctl/pkg/apis"
 	"github.com/chaosnative/chaosctl/pkg/utils"
@@ -28,8 +29,8 @@ import (
 
 // createCmd represents the create command
 var agentCmd = &cobra.Command{
-	Use:   "agent",
-	Short: `Upgrades the ChaosNative Cloud agent plane.`,
+	Use:   "chaos-delegate",
+	Short: `Upgrades the ChaosNative Cloud Chaos Delegate plane.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		credentials, err := utils.GetCredentials(cmd)
 		utils.PrintError(err)
@@ -49,12 +50,12 @@ var agentCmd = &cobra.Command{
 			}
 		}
 
-		cluster_id, err := cmd.Flags().GetString("cluster-id")
+		cluster_id, err := cmd.Flags().GetString("chaos-delegate-id")
 		utils.PrintError(err)
 
 		if cluster_id == "" {
 			prompt := promptui.Prompt{
-				Label: "What's the ClusterID?",
+				Label: "What's the Chaos Delegate ID?",
 			}
 
 			cluster_id, err = prompt.Run()
@@ -72,5 +73,5 @@ var agentCmd = &cobra.Command{
 func init() {
 	UpgradeCmd.AddCommand(agentCmd)
 	agentCmd.Flags().String("project-id", "", "Enter the project ID")
-	agentCmd.Flags().String("cluster-id", "", "Enter the cluster ID")
+	agentCmd.Flags().String("chaos-delegate-id", "", "Enter the Chaos Delegate ID")
 }

--- a/pkg/cmd/upgrade/upgrade.go
+++ b/pkg/cmd/upgrade/upgrade.go
@@ -23,8 +23,8 @@ import (
 var UpgradeCmd = &cobra.Command{
 	Use: "upgrade",
 	Short: `Examples:
-		#upgrade version of your agent
-		chaosctl upgrade agent --cluster-id="4cc25543-36c8-4373-897b-2e5dbbe87bcf" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+		#upgrade version of your chaos delegate
+		chaosctl upgrade chaos-delegate --cluster-id="4cc25543-36c8-4373-897b-2e5dbbe87bcf" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 		Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/cmd/upgrade/upgrade.go
+++ b/pkg/cmd/upgrade/upgrade.go
@@ -24,7 +24,7 @@ var UpgradeCmd = &cobra.Command{
 	Use: "upgrade",
 	Short: `Examples:
 		#upgrade version of your chaos delegate
-		chaosctl upgrade chaos-delegate --cluster-id="4cc25543-36c8-4373-897b-2e5dbbe87bcf" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
+		chaosctl upgrade chaos-delegate --chaos-delegate-id="4cc25543-36c8-4373-897b-2e5dbbe87bcf" --project-id="d861b650-1549-4574-b2ba-ab754058dd04" --non-interactive
 
 		Note: The default location of the config file is $HOME/.chaosconfig, and can be overridden by a --config flag
 	`,

--- a/pkg/k8s/operations.go
+++ b/pkg/k8s/operations.go
@@ -169,7 +169,7 @@ start:
 	}
 	if ok {
 		if podExists(podExistsParams{namespace, label}, kubeconfig) {
-			utils.Red.Println("\n🚫 There is an chaos delegate already present in this namespace. Please enter a different namespace")
+			utils.Red.Println("\n🚫 There is a chaos delegate already present in this namespace. Please enter a different namespace")
 			goto start
 		} else {
 			nsExists = true

--- a/pkg/k8s/operations.go
+++ b/pkg/k8s/operations.go
@@ -169,7 +169,7 @@ start:
 	}
 	if ok {
 		if podExists(podExistsParams{namespace, label}, kubeconfig) {
-			utils.Red.Println("\n🚫 There is an agent already present in this namespace. Please enter a different namespace")
+			utils.Red.Println("\n🚫 There is an chaos delegate already present in this namespace. Please enter a different namespace")
 			goto start
 		} else {
 			nsExists = true
@@ -208,9 +208,9 @@ func WatchPod(params WatchPodParams, kubeconfig *string) {
 		if !ok {
 			log.Fatal("unexpected type")
 		}
-		utils.White_B.Println("💡 Connecting agent to Chaos Center.")
+		utils.White_B.Println("💡 Connecting chaos delegate to Chaos Center.")
 		if p.Status.Phase == "Running" {
-			utils.White_B.Println("🏃 Agents are running!!")
+			utils.White_B.Println("🏃 Chaos Delegates are running!!")
 			watch.Stop()
 			break
 		}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -51,7 +51,7 @@ const (
 	// Chaos agent connection yaml path
 	ChaosYamlPath = "api/file"
 
-	ChaosAgentPath = "agents"
+	ChaosAgentPath = "delegates"
 
 	// Graphql server api path
 	GQLAPIPath = "/api/query"


### PR DESCRIPTION
- Renamed agents to chaos delegates in logs, readme
- Updated `create agent` to `connect chaos-delegate`
- Updated `get agents` to `get chaos-delegates`

Signed-off-by: Sarthak Jain <sarthak.jain@harness.io>